### PR TITLE
Fiks prioritering av henvendelsene

### DIFF
--- a/force-app/main/default/classes/nksGetStoUtilityController.cls
+++ b/force-app/main/default/classes/nksGetStoUtilityController.cls
@@ -198,7 +198,7 @@ public without sharing class nksGetStoUtilityController {
                 AND ServiceChannel.DeveloperName = 'Skriv_til_oss'
                 AND IsReadyForRouting = TRUE
                 AND isPushed = FALSE
-            ORDER BY RoutingPriority, SecondaryRoutingPriority, CreatedDate
+            ORDER BY RoutingPriority, SecondaryRoutingPriority DESC NULLS LAST, CreatedDate
             LIMIT 1
         ];
     }


### PR DESCRIPTION
Korrigerer spørringen sånn at de med sekundærprioritering faktisk kommer først og de uten kommer sist.
Sørger også for at eskalerte som har "1" kommer før videresendte som har "0"